### PR TITLE
Check for virtual keyboard support on switch

### DIFF
--- a/src/conditionals.c
+++ b/src/conditionals.c
@@ -37,7 +37,7 @@ uint8_t supportsVirtualKeyboard(void)
 #elif defined(__SWITCH__)
     // If app is ran in applet mode, SwKbd will not work
     AppletType at = appletGetAppletType();
-    return at == AppletType_Application || at == AppletType_SystemApplication ? 1 : 0;
+    return at == AppletType_Application || at == AppletType_SystemApplication;
 #else
     return 0;
 #endif

--- a/src/conditionals.c
+++ b/src/conditionals.c
@@ -37,7 +37,7 @@ uint8_t supportsVirtualKeyboard(void)
 #elif defined(__SWITCH__)
     // If app is ran in applet mode, SwKbd will not work
     AppletType at = appletGetAppletType();
-    return at == AppletType_Application ? 1 : 0;
+    return at == AppletType_Application || at == AppletType_SystemApplication ? 1 : 0;
 #else
     return 0;
 #endif

--- a/src/conditionals.c
+++ b/src/conditionals.c
@@ -17,6 +17,10 @@
 
 #include "conditionals.h"
 
+#ifdef __SWITCH__
+#include <switch.h>
+#endif
+
 uint8_t supportsRealKeyboard(void)
 {
 #if defined(__vita__) || defined(__SWITCH__) || defined(__PSP__) || defined(_3DS) || defined(__PSL1GHT__) || defined(__WII__) || defined(__WIIU__)
@@ -28,8 +32,12 @@ uint8_t supportsRealKeyboard(void)
 
 uint8_t supportsVirtualKeyboard(void)
 {
-#if defined(__vita__) || defined(__SWITCH__) || defined(_3DS) || defined(__PSL1GHT__)
+#if defined(__vita__) || defined(_3DS) || defined(__PSL1GHT__)
     return 1;
+#elif defined(__SWITCH__)
+    // If app is ran in applet mode, SwKbd will not work
+    AppletType at = appletGetAppletType();
+    return at == AppletType_Application ? 1 : 0;
 #else
     return 0;
 #endif

--- a/src/nx/nxVirtualKeyboard.c
+++ b/src/nx/nxVirtualKeyboard.c
@@ -89,8 +89,12 @@ uint8_t inputVirtualKeyboardText(const char *title, uint16_t maxLength, char *ou
             strncpy(outText, tmpoutstr, maxLength);
 
             success = 1;
+        } else {
+            spLogInfo("Failed to show software keyboard"); 
         }
         swkbdClose(&kbd);
+    } else {
+        spLogInfo("Failed to create software keyboard"); 
     }
 
     return success;

--- a/src/nx/nxVirtualKeyboard.c
+++ b/src/nx/nxVirtualKeyboard.c
@@ -69,13 +69,13 @@ uint8_t inputVirtualKeyboardText(const char *title, uint16_t maxLength, char *ou
 
     gCurrentKeyboardMaxLength = maxLength;
 
-    if (R_SUCCEEDED(rc)) 
+    if (R_SUCCEEDED(rc))
     {
         swkbdConfigMakePresetDefault(&kbd);
         swkbdConfigSetGuideText(&kbd, title);
         swkbdConfigSetInitialText(&kbd, outText);
 
-        swkbdConfigSetTextCheckCallback(&kbd, validateInputText); 
+        swkbdConfigSetTextCheckCallback(&kbd, validateInputText);
 
         // You can also use swkbdConfigSet*() funcs if you want.
 
@@ -89,12 +89,16 @@ uint8_t inputVirtualKeyboardText(const char *title, uint16_t maxLength, char *ou
             strncpy(outText, tmpoutstr, maxLength);
 
             success = 1;
-        } else {
-            spLogInfo("Failed to show software keyboard"); 
+        }
+        else
+        {
+            spLogInfo("Failed to show software keyboard");
         }
         swkbdClose(&kbd);
-    } else {
-        spLogInfo("Failed to create software keyboard"); 
+    }
+    else
+    {
+        spLogInfo("Failed to create software keyboard");
     }
 
     return success;


### PR DESCRIPTION
Fix #4 

Originally I planned to check the return value of the `inputVirtualKeyboardText` function, and fall back to the auto generated one if it failed. Unfortunately, SwKbd fails the same way whether it's an error when creating it or when the user cancels the interaction.

In order to support the cancelation flow, we would have to use InlineKbd, but that's an entirely different flow I'm afraid.

In any case, the check on the conditional should fix the problem I encountered and auto generate a player name for you if you run it on Applet mode :smile: