### PR TITLE
Make it possible on linux to install to /usr and put saves to ~

### DIFF
--- a/src/sdl_common/audio.c
+++ b/src/sdl_common/audio.c
@@ -70,7 +70,12 @@ void destroyMusic(void);
 void loadSounds(void);
 void destroySounds(void);
 
-#ifdef __vita__
+#if defined(FILE_DATA_PATH)
+#define FILE_PATH_STR_HELPER(x) #x
+#define FILE_PATH_STR(x) FILE_PATH_STR_HELPER(x)
+#define FILE_BASE_PATH FILE_PATH_STR(FILE_DATA_PATH)
+static const char *kBaseAudioFolder = FILE_BASE_PATH "/audio";
+#elif defined(__vita__)
 static const char *kBaseAudioFolder = "app0:/audio";
 #elif defined(_3DS)
 static const char *kBaseAudioFolder = "sdmc:/OpenSupaplex/audio";

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -3,9 +3,9 @@ exclude := ../src/sdl_common/audio.c ../src/sdl2/video.c
 src := $(filter-out $(exclude),$(src))
 obj = $(src:.c=.o)
 
-LDFLAGS = -lSDL2_mixer -lvorbis -logg `sdl2-config --libs` -lm
+LDFLAGS += -lSDL2_mixer -lvorbis -logg `sdl2-config --libs` -lm
 
-CFLAGS = `sdl2-config --cflags` -O2 -DHAVE_SDL2
+CFLAGS += `sdl2-config --cflags` -O2 -DHAVE_SDL2
 
 opensupaplex: $(obj)
 	$(CC) -o $@ $^ $(LDFLAGS)


### PR DESCRIPTION
Configurable via CFLAGS: -DFILE_FHS_XDG_DIRS -DFILE_DATA_PATH=/usr/share/OpenSupaplex
Also add OPENSUPAPLEX_PATH env variable to override these paths in
runtime.

Close #7