### PR TITLE
Add scaling to 4:3 as an option

### DIFF
--- a/src/psp/video.c
+++ b/src/psp/video.c
@@ -238,6 +238,13 @@ void updateWindowViewport()
 
     float textureAspectRatio = (float)kScreenWidth / kScreenHeight;
 
+    // The only way in which "aspect correct" differs from "aspect fit"
+    // is that 4:3 is used instead of kScreenWidth:kScreenHeight
+    if (gScalingMode == ScalingModeAspectCorrect)
+    {
+        textureAspectRatio = 4.f/3.f;
+    }
+
     int maxViewportWidth = kWindowWidth;
     int maxViewportHeight = kWindowHeight;
 

--- a/src/sdl1/video.c
+++ b/src/sdl1/video.c
@@ -282,6 +282,13 @@ void updateWindowViewport()
 
     float textureAspectRatio = (float)kScreenWidth / kScreenHeight;
 
+    // The only way in which "aspect correct" differs from "aspect fit"
+    // is that 4:3 is used instead of kScreenWidth:kScreenHeight
+    if (gScalingMode == ScalingModeAspectCorrect)
+    {
+        textureAspectRatio = 4.f/3.f;
+    }
+
     int maxViewportWidth = windowWidth;
     int maxViewportHeight = windowHeight;
 

--- a/src/sdl2/video.c
+++ b/src/sdl2/video.c
@@ -281,6 +281,13 @@ void updateWindowViewport()
 
     float textureAspectRatio = (float)kScreenWidth / kScreenHeight;
 
+    // The only way in which "aspect correct" differs from "aspect fit"
+    // is that 4:3 is used instead of kScreenWidth:kScreenHeight
+    if (gScalingMode == ScalingModeAspectCorrect)
+    {
+        textureAspectRatio = 4.f/3.f;
+    }
+
     int maxViewportWidth = windowWidth;
     int maxViewportHeight = windowHeight;
 

--- a/src/supaplex.c
+++ b/src/supaplex.c
@@ -947,6 +947,7 @@ void buildScalingModeOptionTitle(char output[kMaxAdvancedOptionsMenuEntryTitleLe
     static const char *kAspectFillScalingModeString = "ZOOM";
     static const char *kIntegerFactorScalingModeString = "INTEGER FACTOR";
     static const char *kFullscreenScalingModeString = "FULLSCREEN";
+    static const char *kAspectCorrectScalingModeString = "4:3";
 
     const char *mode = kAspectFitScalingModeString;
 
@@ -960,6 +961,9 @@ void buildScalingModeOptionTitle(char output[kMaxAdvancedOptionsMenuEntryTitleLe
             break;
         case ScalingModeFullscreen:
             mode = kFullscreenScalingModeString;
+            break;
+        case ScalingModeAspectCorrect:
+            mode = kAspectCorrectScalingModeString;
             break;
         default:
             mode = kAspectFitScalingModeString;

--- a/src/video.h
+++ b/src/video.h
@@ -36,6 +36,7 @@ typedef enum {
     ScalingModeAspectFill,
     ScalingModeIntegerFactor,
     ScalingModeFullscreen,
+    ScalingModeAspectCorrect,
     ScalingModeCount,
 } ScalingMode;
 


### PR DESCRIPTION
This adds ScalingModeAspectCorrect to the ScalingMode enum as the last possible mode, thus existing cfg files should still work.

I did have to update the psp, sdl1 and sdl2 ports. Only the sdl ports were tested; I used Ubuntu 20.04.

Known issue with the sdl1 port: When the title screen is shown, the borders will be filled with the palette's first color.
Since the window is currently created using a 8-bit indexed color mode, there might not be a good way to handle this, other than migrating to a true color mode for the window, as used in the sdl2 port. I tried adding calls of the form `SDL_FillRect(gWindowSurface, NULL, 127)` to `setGlobalPaletteColor` and `setColorPalette`. This may appear to work, but it's probably wrong, especially if custom palettes are a possibility.