### PR TITLE
(3DS) Include resources in executables RomFS

### DIFF
--- a/3ds/INSTALL.TXT
+++ b/3ds/INSTALL.TXT
@@ -3,8 +3,8 @@ Thanks for downloading OpenSupaplex for Nintendo 3DS!
 In order to install this, you have two options: using the 3dsx file or install the cia file.
 
 - 3ds file:
-	Just copy the OpenSupaplex and 3ds folders into the root of your SD card and open the 3dsx file with the Homebrew Launcher.
+	Just copy 3ds folder into the root of your SD card and open the 3dsx file with the Homebrew Launcher.
 
 - cia file:
-	Copy the OpenSupaplex folder to the root of your SD card, and then the cia file (inside the cias folder) somewhere in your SD card.
+	Copy the cia file (inside the cia folder) somewhere in your SD card.
 	Once you've done that, use FBI to install the cia file. Then, just run the game from your home screen.

--- a/3ds/INSTALL.TXT
+++ b/3ds/INSTALL.TXT
@@ -3,7 +3,7 @@ Thanks for downloading OpenSupaplex for Nintendo 3DS!
 In order to install this, you have two options: using the 3dsx file or install the cia file.
 
 - 3ds file:
-	Just copy 3ds folder into the root of your SD card and open the 3dsx file with the Homebrew Launcher.
+	Just copy the 3ds folder into the root of your SD card and open the 3dsx file with the Homebrew Launcher.
 
 - cia file:
 	Copy the cia file (inside the cia folder) somewhere in your SD card.

--- a/3ds/Makefile
+++ b/3ds/Makefile
@@ -39,7 +39,7 @@ INCLUDES			:=	include
 EXCLUDE				:=	nullVirtualKeyboard.c
 GRAPHICS			:=	gfx
 GFXBUILD			:=	$(BUILD)
-#ROMFS				:=	romfs
+ROMFS				:=	../resources
 #GFXBUILD			:=	$(ROMFS)/gfx
 APP_TITLE			:=	OpenSupaplex
 APP_PRODUCT_CODE 	:=	CTR-P-OSPX
@@ -143,7 +143,14 @@ else
 	export MAKEROM    = $(TOPDIR)/tools/makerom.exe
 endif
 
-export MAKEROM_ARGS_COMMON = -rsf $(APP_RSF) -exefslogo -elf $(OUTPUT)-strip.elf -icon $(OUTPUT).icn -banner $(OUTPUT).bnr -DAPP_TITLE="$(APP_TITLE)" -DAPP_PRODUCT_CODE="$(APP_PRODUCT_CODE)" -DAPP_UNIQUE_ID=$(APP_UNIQUE_ID)
+MAKEROM_ARGS_COMMON = -rsf $(APP_RSF) -exefslogo -elf $(OUTPUT)-strip.elf -icon $(OUTPUT).icn -banner $(OUTPUT).bnr -DAPP_TITLE="$(APP_TITLE)" -DAPP_PRODUCT_CODE="$(APP_PRODUCT_CODE)" -DAPP_UNIQUE_ID=$(APP_UNIQUE_ID)
+
+ifneq ($(ROMFS),)
+	APP_ROMFS := $(TOPDIR)/$(ROMFS)
+	MAKEROM_ARGS_COMMON += -DAPP_ROMFS="$(APP_ROMFS)"
+endif
+
+export MAKEROM_ARGS_COMMON := $(MAKEROM_ARGS_COMMON)
 
 export T3XFILES		:=	$(GFXFILES:.t3s=.t3x)
 

--- a/3ds/assets/template.rsf
+++ b/3ds/assets/template.rsf
@@ -13,6 +13,9 @@ CardInfo:
   MediaType               : Card1 # Card1 / Card2
   CardDevice              : None # NorFlash(Pick this if you use savedata) / None
   
+RomFs:
+  # Specifies the root path of the read only file system to include in the ROM.
+  RootPath                : $(APP_ROMFS)
 
 Option:
   UseOnSD                 : true # true if App is to be installed to SD

--- a/3ds/ci-build-3ds.sh
+++ b/3ds/ci-build-3ds.sh
@@ -6,7 +6,8 @@ make -j8 || exit 1
 
 # Bundle and prepare for release
 mkdir 3ds
+mkdir 3ds/OpenSupaplex
 mkdir cia
-mv OpenSupaplex.3dsx 3ds/OpenSupaplex.3dsx
+mv OpenSupaplex.3dsx 3ds/OpenSupaplex/OpenSupaplex.3dsx
 mv OpenSupaplex.cia cia/OpenSupaplex.cia
 zip -r OpenSupaplex-3ds.zip 3ds cia INSTALL.TXT

--- a/3ds/ci-build-3ds.sh
+++ b/3ds/ci-build-3ds.sh
@@ -6,8 +6,8 @@ make -j8 || exit 1
 
 # Bundle and prepare for release
 mkdir 3ds
-mkdir 3ds/OpenSupaplex
+mkdir 3ds
 mkdir cia
-mv OpenSupaplex.3dsx 3ds/OpenSupaplex/OpenSupaplex.3dsx
+mv OpenSupaplex.3dsx 3ds/OpenSupaplex.3dsx
 mv OpenSupaplex.cia cia/OpenSupaplex.cia
 zip -r OpenSupaplex-3ds.zip 3ds cia INSTALL.TXT

--- a/3ds/ci-build-3ds.sh
+++ b/3ds/ci-build-3ds.sh
@@ -5,10 +5,8 @@ cd 3ds
 make -j8 || exit 1
 
 # Bundle and prepare for release
-mkdir OpenSupaplex
 mkdir 3ds
-mkdir cias
+mkdir cia
 mv OpenSupaplex.3dsx 3ds/OpenSupaplex.3dsx
-mv OpenSupaplex.cia cias/OpenSupaplex.cia
-cp -R ../resources/* OpenSupaplex/
-zip -r OpenSupaplex-3ds.zip OpenSupaplex 3ds cias INSTALL.TXT
+mv OpenSupaplex.cia cia/OpenSupaplex.cia
+zip -r OpenSupaplex-3ds.zip 3ds cia INSTALL.TXT

--- a/3ds/ci-build-3ds.sh
+++ b/3ds/ci-build-3ds.sh
@@ -6,7 +6,6 @@ make -j8 || exit 1
 
 # Bundle and prepare for release
 mkdir 3ds
-mkdir 3ds
 mkdir cia
 mv OpenSupaplex.3dsx 3ds/OpenSupaplex.3dsx
 mv OpenSupaplex.cia cia/OpenSupaplex.cia

--- a/src/file.c
+++ b/src/file.c
@@ -157,7 +157,9 @@ FILE *openWritableFile(const char *pathname, const char *mode)
 #else // the rest of the platforms just have different base paths
 
 #if defined(_3DS)
-#define FILE_BASE_PATH "sdmc:/OpenSupaplex/"
+#include <sys/stat.h>
+#define FILE_BASE_PATH "romfs:/"
+#define FILE_BASE_WRITABLE_PATH "sdmc:/3ds/OpenSupaplex/"
 #elif defined(__NDS__)
 #define FILE_BASE_PATH "nitro:/resources/"
 #define FILE_BASE_WRITABLE_PATH ""
@@ -205,7 +207,7 @@ FILE *openWritableFile(const char *pathname, const char *mode)
     // Create base folder in a writable area
 #ifdef __vita__
     sceIoMkdir(FILE_BASE_WRITABLE_PATH, 0777);
-#elif defined(__riscos__)
+#elif defined(__riscos__) || defined(_3DS)
     mkdir(FILE_BASE_WRITABLE_PATH, 0777);
 #endif
 

--- a/src/file.c
+++ b/src/file.c
@@ -159,7 +159,7 @@ FILE *openWritableFile(const char *pathname, const char *mode)
 #if defined(_3DS)
 #include <sys/stat.h>
 #define FILE_BASE_PATH "romfs:/"
-#define FILE_BASE_WRITABLE_PATH "sdmc:/3ds/OpenSupaplex/"
+#define FILE_BASE_WRITABLE_PATH "sdmc:/OpenSupaplex/"
 #elif defined(__NDS__)
 #define FILE_BASE_PATH "nitro:/resources/"
 #define FILE_BASE_WRITABLE_PATH ""

--- a/src/sdl_common/audio.c
+++ b/src/sdl_common/audio.c
@@ -75,7 +75,7 @@ static const char *kBaseAudioFolder = FILE_BASE_PATH "/audio";
 #elif defined(__vita__)
 static const char *kBaseAudioFolder = "app0:/audio";
 #elif defined(_3DS)
-static const char *kBaseAudioFolder = "sdmc:/OpenSupaplex/audio";
+static const char *kBaseAudioFolder = "romfs:/audio";
 #elif defined(__PSL1GHT__)
 static const char *kBaseAudioFolder = "/dev_hdd0/game/" PS3APPID "/USRDIR/audio";
 #elif defined(__riscos__)

--- a/src/sdl_common/system.c
+++ b/src/sdl_common/system.c
@@ -59,12 +59,16 @@ void initializeSystem(void)
 		osSetSpeedupEnable(true);
         spLogInfo("Using New3DS speed up for better performance");
     }
+    romfsInit();
 #endif
 }
 
 void destroySystem(void)
 {
     SDL_Quit();
+#if defined(_3DS)
+    romfsExit();
+#endif
 }
 
 uint8_t isOld3DSSystem(void)
@@ -88,6 +92,9 @@ void exitWithError(const char *format, ...)
     vfprintf(stderr, format, argptr);
     va_end(argptr);
     SDL_Quit();
+#if defined(_3DS)
+    romfsExit();
+#endif
     exit(errno);
 }
 


### PR DESCRIPTION
This will include all resources in the RomFS included in the build binaries.

The base folder is set to ```romfs:/```, which includes all resources.
The writable folder has been moved to: ```sdmc:/3ds/OpenSupaplex/```, which will be created if not existing.
