### PR TITLE
remove linking to ogg/vorbis and flac libraries

### DIFF
--- a/3ds/Makefile
+++ b/3ds/Makefile
@@ -76,7 +76,7 @@ CXXFLAGS	:= $(CFLAGS) -fno-rtti -fno-exceptions -std=gnu++11
 ASFLAGS	:=	-g $(ARCH)
 LDFLAGS	=	-specs=3dsx.specs -g $(ARCH) -Wl,-Map,$(notdir $*.map)
 
-LIBS	:= -lSDL_mixer -lSDL -lmikmod -lvorbisidec -logg -lmad -lcitro3d -lctru -lm
+LIBS	:= -lSDL_mixer -lSDL -lmikmod -lmad -lcitro3d -lctru -lm
 
 #---------------------------------------------------------------------------------
 # list of directories containing libraries, this must be the top level containing

--- a/linux/Makefile
+++ b/linux/Makefile
@@ -1,7 +1,7 @@
 src = $(wildcard ../src/*.c) $(wildcard ../src/sdl2/*.c) $(wildcard ../src/sdl_common/*.c) ../src/lib/ini/ini.c ../src/null/virtualKeyboard.c
 obj = $(src:.c=.o)
 
-LDFLAGS += -lSDL2_mixer -lvorbis -logg `sdl2-config --libs` -lm
+LDFLAGS += -lSDL2_mixer `sdl2-config --libs` -lm
 
 CFLAGS += `sdl2-config --cflags` -DHAVE_SDL2
 

--- a/macos/OpenSupaplex/OpenSupaplex.xcodeproj/project.pbxproj
+++ b/macos/OpenSupaplex/OpenSupaplex.xcodeproj/project.pbxproj
@@ -1053,9 +1053,6 @@
 					"-L/usr/local/lib",
 					"-lSDL2_mixer",
 					"-lSDL2",
-					"-lvorbisfile",
-					"-lvorbis",
-					"-logg",
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = com.OpenSupaplex;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -1083,9 +1080,6 @@
 					"-L/usr/local/lib",
 					"-lSDL2_mixer",
 					"-lSDL2",
-					"-lvorbisfile",
-					"-lvorbis",
-					"-logg",
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = com.OpenSupaplex;
 				PRODUCT_NAME = "$(TARGET_NAME)";

--- a/ps3/Makefile
+++ b/ps3/Makefile
@@ -39,7 +39,7 @@ CFLAGS		=	-O2 -Wall -mcpu=cell $(MACHDEP) $(INCLUDE) $(LIBPSL1GHT_INC) -I$(PORTL
 #---------------------------------------------------------------------------------
 # any extra libraries we wish to link with the project
 #---------------------------------------------------------------------------------
-LIBS	:=	-lSDL2_mixer -lvorbisfile -lvorbis -logg -lmikmod -lSDL2 -lrsx -lgcm_sys -lio -laudio -lsysutil -lrt -llv2 -lm
+LIBS	:=	-lSDL2_mixer -lmikmod -lSDL2 -lrsx -lgcm_sys -lio -laudio -lsysutil -lrt -llv2 -lm
 
 ifeq ($(DEBUG),1)
 	CFLAGS += -DDEBUG=1 -DDEBUGNET

--- a/psp/Makefile
+++ b/psp/Makefile
@@ -11,7 +11,7 @@ ASFLAGS = $(CFLAGS)
 
 LIBDIR = 
 LDFLAGS = 
-LIBS = -lSDL_mixer -lvorbisfile -lvorbis -logg -lSDL -lSDLmain -lGL -lGLU -lmikmod -lpspaudiolib -lpspaudio -lm \
+LIBS = -lSDL_mixer -lSDL -lSDLmain -lGL -lGLU -lmikmod -lpspaudiolib -lpspaudio -lm \
 	   -lpspgu -lpspvfpu -lpsprtc -lpspvram -lpsphprm -lpspirkeyb -lpsppower
 
 EXTRA_TARGETS = EBOOT.PBP

--- a/riscos/Makefile
+++ b/riscos/Makefile
@@ -3,7 +3,7 @@ obj = $(src:.c=.o)
 
 CC=arm-unknown-riscos-gcc
 CFLAGS = -O3 -std=c99 -I$(GCCSDK_INSTALL_ENV)/include -DHAVE_SDL
-LDFLAGS = -static -L$(GCCSDK_INSTALL_ENV)/lib -lSDL_mixer -lSDL -lvorbisidec -logg -lmikmod
+LDFLAGS = -static -L$(GCCSDK_INSTALL_ENV)/lib -lSDL_mixer -lSDL -lmikmod
 ZIP = $(GCCSDK_INSTALL_ENV)/bin/zip
 
 all: !OSupaplex/!RunImage,ff8 !OSupaplex/data !OSupaplex/audio

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -3,7 +3,7 @@ exclude := ../src/sdl_common/audio.c ../src/sdl2/video.c
 src := $(filter-out $(exclude),$(src))
 obj = $(src:.c=.o)
 
-LDFLAGS += -lSDL2_mixer -lvorbis -logg `sdl2-config --libs` -lm
+LDFLAGS += -lSDL2_mixer `sdl2-config --libs` -lm
 
 CFLAGS += `sdl2-config --cflags` -O2 -DHAVE_SDL2
 

--- a/wasm/Makefile
+++ b/wasm/Makefile
@@ -3,7 +3,7 @@ CC=emcc
 src = $(wildcard ../src/*.c) $(wildcard ../src/sdl2/*.c) $(wildcard ../src/sdl_common/*.c) ../src/null/virtualKeyboard.c ../src/lib/ini/ini.c
 obj = $(src:.c=.o)
 
-LDFLAGS = -lSDL2_mixer -lvorbis -logg -lSDL2
+LDFLAGS = -lSDL2_mixer -lSDL2
 
 CFLAGS = -s USE_SDL=2 -s USE_SDL_MIXER=2 -DHAVE_SDL2
 

--- a/windows/Makefile
+++ b/windows/Makefile
@@ -1,7 +1,7 @@
 src = $(wildcard ../src/*.c) $(wildcard ../src/sdl2/*.c) $(wildcard ../src/sdl_common/*.c) ../src/null/virtualKeyboard.c ../src/lib/ini/ini.c
 obj = $(src:.c=.o)
 
-LDFLAGS = -lSDL2_mixer -lvorbis -lFLAC -logg `sdl2-config --libs` `pkg-config SDL2_mixer --libs` -lm
+LDFLAGS = -lSDL2_mixer `sdl2-config --libs` `pkg-config SDL2_mixer --libs` -lm
 
 CFLAGS = `sdl2-config --cflags` `pkg-config SDL2_mixer --cflags` -DHAVE_SDL2
 

--- a/windows/Makefile.sdl1
+++ b/windows/Makefile.sdl1
@@ -1,7 +1,7 @@
 src = $(wildcard ../src/*.c) $(wildcard ../src/sdl1/*.c) $(wildcard ../src/sdl_common/*.c) ../src/null/virtualKeyboard.c ../src/lib/ini/ini.c
 obj = $(src:.c=.o)
 
-LDFLAGS = -lSDL_mixer -lvorbis -lFLAC -logg `sdl-config --libs` `pkg-config SDL_mixer --libs` -lm
+LDFLAGS = -lSDL_mixer `sdl-config --libs` `pkg-config SDL_mixer --libs` -lm
 
 CFLAGS = `sdl-config --cflags` `pkg-config SDL_mixer --cflags` -DHAVE_SDL
 


### PR DESCRIPTION
Removes need to install some libraries that are now not used. No idea why only Windows linked to FLAC, since there are no FLAC sound files.

I've tested the Linux branch; don't have the other operating systems.