### PR TITLE
Revert recent makefile changes to 3DS, PS3 and PSP

### DIFF
--- a/3ds/Makefile
+++ b/3ds/Makefile
@@ -76,7 +76,7 @@ CXXFLAGS	:= $(CFLAGS) -fno-rtti -fno-exceptions -std=gnu++11
 ASFLAGS	:=	-g $(ARCH)
 LDFLAGS	=	-specs=3dsx.specs -g $(ARCH) -Wl,-Map,$(notdir $*.map)
 
-LIBS	:= -lSDL_mixer -lSDL -lmikmod -lmad -lcitro3d -lctru -lm
+LIBS	:= -lSDL_mixer -lSDL -lmikmod -lvorbisidec -logg -lmad -lcitro3d -lctru -lm
 
 #---------------------------------------------------------------------------------
 # list of directories containing libraries, this must be the top level containing

--- a/ps3/Makefile
+++ b/ps3/Makefile
@@ -39,7 +39,7 @@ CFLAGS		=	-O2 -Wall -mcpu=cell $(MACHDEP) $(INCLUDE) $(LIBPSL1GHT_INC) -I$(PORTL
 #---------------------------------------------------------------------------------
 # any extra libraries we wish to link with the project
 #---------------------------------------------------------------------------------
-LIBS	:=	-lSDL2_mixer -lmikmod -lSDL2 -lrsx -lgcm_sys -lio -laudio -lsysutil -lrt -llv2 -lm
+LIBS	:=	-lSDL2_mixer -lvorbisfile -lvorbis -logg -lmikmod -lSDL2 -lrsx -lgcm_sys -lio -laudio -lsysutil -lrt -llv2 -lm
 
 ifeq ($(DEBUG),1)
 	CFLAGS += -DDEBUG=1 -DDEBUGNET

--- a/psp/Makefile
+++ b/psp/Makefile
@@ -11,7 +11,7 @@ ASFLAGS = $(CFLAGS)
 
 LIBDIR = 
 LDFLAGS = 
-LIBS = -lSDL_mixer -lSDL -lSDLmain -lGL -lGLU -lmikmod -lpspaudiolib -lpspaudio -lm \
+LIBS = -lSDL_mixer -lvorbisfile -lvorbis -logg -lSDL -lSDLmain -lGL -lGLU -lmikmod -lpspaudiolib -lpspaudio -lm \
 	   -lpspgu -lpspvfpu -lpsprtc -lpspvram -lpsphprm -lpspirkeyb -lpsppower
 
 EXTRA_TARGETS = EBOOT.PBP


### PR DESCRIPTION
Recently removed from #27 , some platforms still require us to link to OGG and FLAC libraries even when they're not used 🤷‍♂️ 