### PR TITLE
move freely debug cmd rolls back when already moving freely

### DIFF
--- a/src/supaplex.c
+++ b/src/supaplex.c
@@ -1167,7 +1167,11 @@ void handleRemoveSnikSnakOptionSelection()
 
 void handleMoveScrollOptionSelection()
 {
-    gIsMoveScrollModeEnabled = 1;
+    if (gIsMoveScrollModeEnabled == 0) {
+        gIsMoveScrollModeEnabled = 1;
+    } else {
+        gIsMoveScrollModeEnabled = 0;
+    }
     gShouldCloseAdvancedMenu = 1;
 }
 


### PR DESCRIPTION
Sometimes it is useful to investigate the map with the debug option "Move Freely" but later the player might need to control Murphy.
Another option to do this is to add a separate debug cmd, let me know if that is a better approach.