### PR TITLE
Add a docker image for RISC OS builds

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -145,6 +145,21 @@ jobs:
         with:
           name: 3ds-build
           path: 3ds/OpenSupaplex-3ds.zip
+  build-riscos:
+    name: RISC OS
+    runs-on: ubuntu-18.04
+    container: sergiou87/riscos-docker-open-supaplex:7.2
+    steps:
+      - uses: actions/checkout@v1
+      - name: Build OpenSupaplex
+        run: |
+          ./riscos/ci-build.sh
+        shell: bash
+      - name: Upload artifact
+        uses: actions/upload-artifact@v1
+        with:
+          name: riscos-build
+          path: riscos/OpenSupaplex-riscos.zip
   build-windows-x86_64:
     name: Windows x86_64
     runs-on: windows-latest
@@ -172,6 +187,7 @@ jobs:
         build-macos,
         build-switch,
         build-3ds,
+        build-riscos,
         build-windows-x86_64,
         build-psp,
         build-ps3,
@@ -224,6 +240,10 @@ jobs:
         uses: actions/download-artifact@v1
         with:
           name: 3ds-build
+      - name: Download RISC OS Build Asset
+        uses: actions/download-artifact@v1
+        with:
+          name: riscos-build
       - name: Download Windows x86_64 Build Asset
         uses: actions/download-artifact@v1
         with:
@@ -310,6 +330,15 @@ jobs:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
           asset_path: 3ds-build/OpenSupaplex-3ds.zip
           asset_name: OpenSupaplex-3ds-${{ inputs.version }}.zip
+          asset_content_type: application/zip
+      - name: Upload RISC OS Build Asset
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: riscos-build/OpenSupaplex-riscos.zip
+          asset_name: OpenSupaplex-riscos-${{ inputs.version }}.zip
           asset_content_type: application/zip
       - name: Upload Windows x86_64 Build Asset
         uses: actions/upload-release-asset@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -143,6 +143,21 @@ jobs:
         with:
           name: 3ds-build
           path: 3ds/OpenSupaplex-3ds.zip
+  build-riscos:
+    name: RISC OS
+    runs-on: ubuntu-18.04
+    container: sergiou87/riscos-docker-open-supaplex:7.2
+    steps:
+      - uses: actions/checkout@v1
+      - name: Build OpenSupaplex
+        run: |
+          ./riscos/ci-build.sh
+        shell: bash
+      - name: Upload artifact
+        uses: actions/upload-artifact@v1
+        with:
+          name: riscos-build
+          path: riscos/OpenSupaplex-riscos.zip
   build-windows-x86_64:
     name: Windows x86_64
     runs-on: windows-latest

--- a/.gitignore
+++ b/.gitignore
@@ -70,6 +70,7 @@ wasm/opensupaplex.wasm
 
 # RISC OS stuff
 riscos/*,e1f
+riscos/*.zip
 riscos/\!OSupaplex/*,ff8
 riscos/\!OSupaplex/audio
 riscos/\!OSupaplex/data

--- a/ci/Dockerfile-riscos
+++ b/ci/Dockerfile-riscos
@@ -1,0 +1,18 @@
+FROM riscosdotinfo/riscos-gccsdk-4.7:latest
+
+MAINTAINER Sergio Padrino (@sergiou87)
+
+# Update all packages and install SDL and SDL_mixer for RISC OS
+
+RUN apt-get update && apt-get -y install automake1.11 meson cmake rsync
+
+WORKDIR /tmp
+RUN svn co svn://svn.riscos.info/gccsdk/trunk/autobuilder/ autobuilder && \
+	mkdir build && \
+	cd build && \
+	../autobuilder/build -v libsdl1.2debian libsdl-mixer1.2 && \
+	cd .. && \
+	rm -rf autobuilder/ build/
+
+WORKDIR /src
+CMD ["/bin/bash"]

--- a/riscos/Makefile
+++ b/riscos/Makefile
@@ -3,7 +3,7 @@ obj = $(src:.c=.o)
 
 CC=arm-unknown-riscos-gcc
 CFLAGS = -O3 -std=c99 -I$(GCCSDK_INSTALL_ENV)/include -DHAVE_SDL
-LDFLAGS = -static -L$(GCCSDK_INSTALL_ENV)/lib -lSDL_mixer -lSDL -lmikmod
+LDFLAGS = -static -L$(GCCSDK_INSTALL_ENV)/lib -lSDL_mixer -lSDL -lmikmod -lvorbisidec -logg
 ZIP = $(GCCSDK_INSTALL_ENV)/bin/zip
 
 all: !OSupaplex/!RunImage,ff8 !OSupaplex/data !OSupaplex/audio
@@ -22,7 +22,7 @@ opensupaplex,e1f: $(obj)
 	mkdir -p $@
 	cp $^ $@
 
-open-supaplex-riscos.zip: all
+OpenSupaplex-riscos.zip: all
 	$(RM) $@
 	$(ZIP) -,9r $@ !OSupaplex
 

--- a/riscos/ci-build.sh
+++ b/riscos/ci-build.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+source /home/riscos/gccsdk-params
+cd riscos
+make -j8 OpenSupaplex-riscos.zip || exit 1


### PR DESCRIPTION
The CI workflows have also been updated, but are disabled for now.