### PR TITLE
Update Makefile

### DIFF
--- a/ps2/Makefile
+++ b/ps2/Makefile
@@ -18,7 +18,7 @@ ASFLAGS = $(CFLAGS)
 CFLAGS += -D__PS2__ -Dmain=SDL_main -DHAVE_SDL2
 
 LDFLAGS += -L$(PS2DEV)/gsKit/lib -L$(PS2SDK)/ports/lib -L.
-LIBS += -lSDL2main -lSDL2 -lSDL2_mixer -lpatches -lgskit -ldmakit -lps2_drivers -lxmp
+LIBS += -lSDL2main -lSDL2 -lSDL2_mixer -lpatches -lgskit -ldmakit -lps2_drivers -lmodplug
 
 SRC = $(wildcard ../src/*.c) $(wildcard ../src/sdl_common/*.c) $(wildcard ../src/sdl2/*.c) ../src/null/virtualKeyboard.c ../src/lib/ini/ini.c
 EXCLUDE = ../src/sdl1/video.c


### PR DESCRIPTION
I was trying to build it with the latest ps2sdk, and I was getting a link error due to a missing `modplug` library:

```
mips64r5900el-ps2-elf-g++ -T/usr/local/ps2dev/ps2sdk/ee/startup/linkfile -O2 -o OpenSupaplex-debug.elf ../src/animations.o ../src/buttonBorders.o ../src/commandLineParser.o ../src/conditionals.o ../src/config.o ../src/demo.o ../src/file.o ../src/globals.o ../src/graphics.o ../src/input.o ../src/logging.o ../src/menu.o ../src/savegame.o ../src/supaplex.o ../src/utils.o ../src/sdl_common/audio.o ../src/sdl_common/system.o ../src/sdl2/controller.o ../src/sdl2/keyboard.o ../src/sdl2/touchscreen.o ../src/sdl2/video.o ../src/null/virtualKeyboard.o ../src/lib/ini/ini.o -L/usr/local/ps2dev/ps2sdk/ee/lib -Wl,-zmax-page-size=128 -s -L/usr/local/ps2dev/gsKit/lib -L/usr/local/ps2dev/ps2sdk/ports/lib -L. -lSDL2main -lSDL2 -lSDL2_mixer -lpatches -lgskit -ldmakit -lps2_drivers -lxmp
/usr/local/ps2dev/ee/bin/../lib/gcc/mips64r5900el-ps2-elf/11.3.0/../../../../mips64r5900el-ps2-elf/bin/ld: /usr/local/ps2dev/ps2sdk/ports/lib/libSDL2_mixer.a(music_modplug.c.obj): in function `MODPLUG_Load':
music_modplug.c:(.text+0x10): undefined reference to `ModPlug_Load'
/usr/local/ps2dev/ee/bin/../lib/gcc/mips64r5900el-ps2-elf/11.3.0/../../../../mips64r5900el-ps2-elf/bin/ld: music_modplug.c:(.text+0x18): undefined reference to `ModPlug_Load'
/usr/local/ps2dev/ee/bin/../lib/gcc/mips64r5900el-ps2-elf/11.3.0/../../../../mips64r5900el-ps2-elf/bin/ld: music_modplug.c:(.text+0x24): undefined reference to `ModPlug_Unload'
/usr/local/ps2dev/ee/bin/../lib/gcc/mips64r5900el-ps2-elf/11.3.0/../../../../mips64r5900el-ps2-elf/bin/ld: music_modplug.c:(.text+0x28): undefined reference to `ModPlug_Unload'
/usr/local/ps2dev/ee/bin/../lib/gcc/mips64r5900el-ps2-elf/11.3.0/../../../../mips64r5900el-ps2-elf/bin/ld: music_modplug.c:(.text+0x30): undefined reference to `ModPlug_Read'
.......
```

I'm updating the makefile so it can link `modplug` as expected.