### PR TITLE
Fix tests

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -41,7 +41,7 @@ jobs:
           path: macos/OpenSupaplex-macOS.zip
   build-vita:
     name: PS Vita
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     container: sergiou87/vita-docker-open-supaplex:7.2
     steps:
       - uses: actions/checkout@v1
@@ -71,7 +71,7 @@ jobs:
           path: switch/OpenSupaplex-switch.zip
   build-psp:
     name: PSP
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     container: sergiou87/pspdev-docker-open-supaplex:7.1
     steps:
       - uses: actions/checkout@v1
@@ -87,7 +87,7 @@ jobs:
           path: psp/OpenSupaplex-psp.zip
   build-ps3:
     name: PS3
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     container: sergiou87/ps3dev-docker-open-supaplex:7.2
     steps:
       - uses: actions/checkout@v1
@@ -102,7 +102,7 @@ jobs:
           path: ps3/OpenSupaplex.pkg
   build-wii:
     name: Wii
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     container: sergiou87/wii-docker-open-supaplex:7.2
     steps:
       - uses: actions/checkout@v1
@@ -117,7 +117,7 @@ jobs:
           path: wii/OpenSupaplex-wii.zip
   build-wiiu:
     name: Wii U
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     container: sergiou87/wiiu-docker-open-supaplex:7.2
     steps:
       - uses: actions/checkout@v1
@@ -132,7 +132,7 @@ jobs:
           path: wiiu/OpenSupaplex-wiiu.zip
   build-nds:
     name: Nintendo DS
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     container: sergiou87/nds-docker-open-supaplex:7.2
     steps:
       - uses: actions/checkout@v1
@@ -147,7 +147,7 @@ jobs:
           path: nds/OpenSupaplex.nds
   build-3ds:
     name: Nintendo 3DS
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     container: sergiou87/3ds-docker-open-supaplex:7.1
     steps:
       - uses: actions/checkout@v1
@@ -162,7 +162,7 @@ jobs:
           path: 3ds/OpenSupaplex-3ds.zip
   build-riscos:
     name: RISC OS
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     container: sergiou87/riscos-docker-open-supaplex:7.2
     steps:
       - uses: actions/checkout@v1

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -16,7 +16,7 @@ on:
 jobs:
   build-linux:
     name: Linux
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1
       - name: Build OpenSupaplex
@@ -41,7 +41,7 @@ jobs:
           path: macos/OpenSupaplex-macOS.zip
   build-vita:
     name: PS Vita
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     container: sergiou87/vita-docker-open-supaplex:7.2
     steps:
       - uses: actions/checkout@v1
@@ -56,7 +56,7 @@ jobs:
           path: vita/build/OpenSupaplex.vpk
   build-switch:
     name: Nintendo Switch
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     container: sergiou87/switch-docker-open-supaplex:7.1
     steps:
       - uses: actions/checkout@v1
@@ -71,7 +71,7 @@ jobs:
           path: switch/OpenSupaplex-switch.zip
   build-psp:
     name: PSP
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     container: sergiou87/pspdev-docker-open-supaplex:7.1
     steps:
       - uses: actions/checkout@v1
@@ -87,7 +87,7 @@ jobs:
           path: psp/OpenSupaplex-psp.zip
   build-ps3:
     name: PS3
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     container: sergiou87/ps3dev-docker-open-supaplex:7.2
     steps:
       - uses: actions/checkout@v1
@@ -102,7 +102,7 @@ jobs:
           path: ps3/OpenSupaplex.pkg
   build-wii:
     name: Wii
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     container: sergiou87/wii-docker-open-supaplex:7.2
     steps:
       - uses: actions/checkout@v1
@@ -117,7 +117,7 @@ jobs:
           path: wii/OpenSupaplex-wii.zip
   build-wiiu:
     name: Wii U
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     container: sergiou87/wiiu-docker-open-supaplex:7.2
     steps:
       - uses: actions/checkout@v1
@@ -132,7 +132,7 @@ jobs:
           path: wiiu/OpenSupaplex-wiiu.zip
   build-nds:
     name: Nintendo DS
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     container: sergiou87/nds-docker-open-supaplex:7.2
     steps:
       - uses: actions/checkout@v1
@@ -147,7 +147,7 @@ jobs:
           path: nds/OpenSupaplex.nds
   build-3ds:
     name: Nintendo 3DS
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     container: sergiou87/3ds-docker-open-supaplex:7.1
     steps:
       - uses: actions/checkout@v1
@@ -162,7 +162,7 @@ jobs:
           path: 3ds/OpenSupaplex-3ds.zip
   build-riscos:
     name: RISC OS
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     container: sergiou87/riscos-docker-open-supaplex:7.2
     steps:
       - uses: actions/checkout@v1

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -35,7 +35,7 @@ jobs:
           ./macos/ci-build.sh
         shell: bash
       - name: Upload artifact
-        uses: actions/upload-artifact@v1
+        uses: actions/upload-artifact@v4
         with:
           name: macos-build
           path: macos/OpenSupaplex-macOS.zip
@@ -50,7 +50,7 @@ jobs:
           ./vita/ci-build-vita.sh
         shell: bash
       - name: Upload artifact
-        uses: actions/upload-artifact@v1
+        uses: actions/upload-artifact@v4
         with:
           name: vita-build
           path: vita/build/OpenSupaplex.vpk
@@ -65,7 +65,7 @@ jobs:
           ./switch/ci-build-switch.sh
         shell: bash
       - name: Upload artifact
-        uses: actions/upload-artifact@v1
+        uses: actions/upload-artifact@v4
         with:
           name: switch-build
           path: switch/OpenSupaplex-switch.zip
@@ -81,7 +81,7 @@ jobs:
           ./psp/ci-build.sh
         shell: bash
       - name: Upload artifact
-        uses: actions/upload-artifact@v1
+        uses: actions/upload-artifact@v4
         with:
           name: psp-build
           path: psp/OpenSupaplex-psp.zip
@@ -96,7 +96,7 @@ jobs:
           ./ps3/ci-build.sh
         shell: bash
       - name: Upload artifact
-        uses: actions/upload-artifact@v1
+        uses: actions/upload-artifact@v4
         with:
           name: ps3-build
           path: ps3/OpenSupaplex.pkg
@@ -111,7 +111,7 @@ jobs:
           ./wii/ci-build.sh
         shell: bash
       - name: Upload artifact
-        uses: actions/upload-artifact@v1
+        uses: actions/upload-artifact@v4
         with:
           name: wii-build
           path: wii/OpenSupaplex-wii.zip
@@ -126,7 +126,7 @@ jobs:
           ./wiiu/ci-build.sh
         shell: bash
       - name: Upload artifact
-        uses: actions/upload-artifact@v1
+        uses: actions/upload-artifact@v4
         with:
           name: wiiu-build
           path: wiiu/OpenSupaplex-wiiu.zip
@@ -141,7 +141,7 @@ jobs:
           ./nds/ci-build-nds.sh
         shell: bash
       - name: Upload artifact
-        uses: actions/upload-artifact@v1
+        uses: actions/upload-artifact@v4
         with:
           name: nds-build
           path: nds/OpenSupaplex.nds
@@ -156,7 +156,7 @@ jobs:
           ./3ds/ci-build-3ds.sh
         shell: bash
       - name: Upload artifact
-        uses: actions/upload-artifact@v1
+        uses: actions/upload-artifact@v4
         with:
           name: 3ds-build
           path: 3ds/OpenSupaplex-3ds.zip
@@ -171,7 +171,7 @@ jobs:
           ./riscos/ci-build.sh
         shell: bash
       - name: Upload artifact
-        uses: actions/upload-artifact@v1
+        uses: actions/upload-artifact@v4
         with:
           name: riscos-build
           path: riscos/OpenSupaplex-riscos.zip
@@ -190,7 +190,7 @@ jobs:
           cd windows
           msys2 -c './ci-build.sh x86_64'
       - name: Upload artifact
-        uses: actions/upload-artifact@v1
+        uses: actions/upload-artifact@v4
         with:
           name: windows-x86_64-build
           path: windows/OpenSupaplex-windows-x86_64.zip
@@ -225,47 +225,47 @@ jobs:
         shell: bash
         if: ${{ !inputs.release_notes }}
       - name: Download macOS Build Asset
-        uses: actions/download-artifact@v1
+        uses: actions/download-artifact@v4
         with:
           name: macos-build
       - name: Download PS Vita Build Asset
-        uses: actions/download-artifact@v1
+        uses: actions/download-artifact@v4
         with:
           name: vita-build
       - name: Download Nintendo Switch Build Asset
-        uses: actions/download-artifact@v1
+        uses: actions/download-artifact@v4
         with:
           name: switch-build
       - name: Download PSP Build Asset
-        uses: actions/download-artifact@v1
+        uses: actions/download-artifact@v4
         with:
           name: psp-build
       - name: Download PS3 Build Asset
-        uses: actions/download-artifact@v1
+        uses: actions/download-artifact@v4
         with:
           name: ps3-build
       - name: Download Wii Build Asset
-        uses: actions/download-artifact@v1
+        uses: actions/download-artifact@v4
         with:
           name: wii-build
       - name: Download Wii U Build Asset
-        uses: actions/download-artifact@v1
+        uses: actions/download-artifact@v4
         with:
           name: wiiu-build
       - name: Download Nintendo DS Build Asset
-        uses: actions/download-artifact@v1
+        uses: actions/download-artifact@v4
         with:
           name: nds-build
       - name: Download Nintendo 3DS Build Asset
-        uses: actions/download-artifact@v1
+        uses: actions/download-artifact@v4
         with:
           name: 3ds-build
       - name: Download RISC OS Build Asset
-        uses: actions/download-artifact@v1
+        uses: actions/download-artifact@v4
         with:
           name: riscos-build
       - name: Download Windows x86_64 Build Asset
-        uses: actions/download-artifact@v1
+        uses: actions/download-artifact@v4
         with:
           name: windows-x86_64-build
       - name: Create Release

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -50,7 +50,7 @@ jobs:
           ./vita/ci-build-vita.sh
         shell: bash
       - name: Upload artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v1
         with:
           name: vita-build
           path: vita/build/OpenSupaplex.vpk
@@ -65,7 +65,7 @@ jobs:
           ./switch/ci-build-switch.sh
         shell: bash
       - name: Upload artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload1
         with:
           name: switch-build
           path: switch/OpenSupaplex-switch.zip
@@ -81,7 +81,7 @@ jobs:
           ./psp/ci-build.sh
         shell: bash
       - name: Upload artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v1
         with:
           name: psp-build
           path: psp/OpenSupaplex-psp.zip
@@ -96,7 +96,7 @@ jobs:
           ./ps3/ci-build.sh
         shell: bash
       - name: Upload artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v1
         with:
           name: ps3-build
           path: ps3/OpenSupaplex.pkg
@@ -111,7 +111,7 @@ jobs:
           ./wii/ci-build.sh
         shell: bash
       - name: Upload artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v1
         with:
           name: wii-build
           path: wii/OpenSupaplex-wii.zip
@@ -126,7 +126,7 @@ jobs:
           ./wiiu/ci-build.sh
         shell: bash
       - name: Upload artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v1
         with:
           name: wiiu-build
           path: wiiu/OpenSupaplex-wiiu.zip
@@ -141,7 +141,7 @@ jobs:
           ./nds/ci-build-nds.sh
         shell: bash
       - name: Upload artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v1
         with:
           name: nds-build
           path: nds/OpenSupaplex.nds
@@ -156,7 +156,7 @@ jobs:
           ./3ds/ci-build-3ds.sh
         shell: bash
       - name: Upload artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v1
         with:
           name: 3ds-build
           path: 3ds/OpenSupaplex-3ds.zip
@@ -171,7 +171,7 @@ jobs:
           ./riscos/ci-build.sh
         shell: bash
       - name: Upload artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v1
         with:
           name: riscos-build
           path: riscos/OpenSupaplex-riscos.zip

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,7 +48,7 @@ jobs:
           ./vita/ci-build-vita.sh
         shell: bash
       - name: Upload artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v1
         with:
           name: vita-build
           path: vita/build/OpenSupaplex.vpk
@@ -63,7 +63,7 @@ jobs:
           ./switch/ci-build-switch.sh
         shell: bash
       - name: Upload artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v1
         with:
           name: switch-build
           path: switch/OpenSupaplex-switch.zip
@@ -79,7 +79,7 @@ jobs:
           ./psp/ci-build.sh
         shell: bash
       - name: Upload artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v1
         with:
           name: psp-build
           path: psp/OpenSupaplex-psp.zip
@@ -94,7 +94,7 @@ jobs:
           ./ps3/ci-build.sh
         shell: bash
       - name: Upload artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v1
         with:
           name: ps3-build
           path: ps3/OpenSupaplex.pkg
@@ -109,7 +109,7 @@ jobs:
           ./wii/ci-build.sh
         shell: bash
       - name: Upload artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v1
         with:
           name: wii-build
           path: wii/OpenSupaplex-wii.zip
@@ -124,7 +124,7 @@ jobs:
           ./wiiu/ci-build.sh
         shell: bash
       - name: Upload artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v1
         with:
           name: wiiu-build
           path: wiiu/OpenSupaplex-wiiu.zip
@@ -139,7 +139,7 @@ jobs:
           ./nds/ci-build-nds.sh
         shell: bash
       - name: Upload artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v1
         with:
           name: nds-build
           path: nds/OpenSupaplex.nds
@@ -154,7 +154,7 @@ jobs:
           ./3ds/ci-build-3ds.sh
         shell: bash
       - name: Upload artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v1
         with:
           name: 3ds-build
           path: 3ds/OpenSupaplex-3ds.zip
@@ -169,7 +169,7 @@ jobs:
           ./riscos/ci-build.sh
         shell: bash
       - name: Upload artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v1
         with:
           name: riscos-build
           path: riscos/OpenSupaplex-riscos.zip

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   build-linux:
     name: Linux
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1
       - name: Build OpenSupaplex
@@ -39,7 +39,7 @@ jobs:
           path: macos/OpenSupaplex-macOS.zip
   build-vita:
     name: PS Vita
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     container: sergiou87/vita-docker-open-supaplex:7.2
     steps:
       - uses: actions/checkout@v1
@@ -54,7 +54,7 @@ jobs:
           path: vita/build/OpenSupaplex.vpk
   build-switch:
     name: Nintendo Switch
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     container: sergiou87/switch-docker-open-supaplex:7.1
     steps:
       - uses: actions/checkout@v1
@@ -69,7 +69,7 @@ jobs:
           path: switch/OpenSupaplex-switch.zip
   build-psp:
     name: PSP
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     container: sergiou87/pspdev-docker-open-supaplex:7.1
     steps:
       - uses: actions/checkout@v1
@@ -85,7 +85,7 @@ jobs:
           path: psp/OpenSupaplex-psp.zip
   build-ps3:
     name: PS3
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     container: sergiou87/ps3dev-docker-open-supaplex:7.2
     steps:
       - uses: actions/checkout@v1
@@ -100,7 +100,7 @@ jobs:
           path: ps3/OpenSupaplex.pkg
   build-wii:
     name: Wii
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     container: sergiou87/wii-docker-open-supaplex:7.2
     steps:
       - uses: actions/checkout@v1
@@ -115,7 +115,7 @@ jobs:
           path: wii/OpenSupaplex-wii.zip
   build-wiiu:
     name: Wii U
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     container: sergiou87/wiiu-docker-open-supaplex:7.2
     steps:
       - uses: actions/checkout@v1
@@ -130,7 +130,7 @@ jobs:
           path: wiiu/OpenSupaplex-wiiu.zip
   build-nds:
     name: Nintendo DS
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     container: sergiou87/nds-docker-open-supaplex:7.2
     steps:
       - uses: actions/checkout@v1
@@ -145,7 +145,7 @@ jobs:
           path: nds/OpenSupaplex.nds
   build-3ds:
     name: Nintendo 3DS
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     container: sergiou87/3ds-docker-open-supaplex:7.1
     steps:
       - uses: actions/checkout@v1
@@ -160,7 +160,7 @@ jobs:
           path: 3ds/OpenSupaplex-3ds.zip
   build-riscos:
     name: RISC OS
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     container: sergiou87/riscos-docker-open-supaplex:7.2
     steps:
       - uses: actions/checkout@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
           ./linux/ci-build.sh
         shell: bash
       - name: Linux artifact
-        uses: actions/upload-artifact@v1
+        uses: actions/upload-artifact@v4
         with:
           name: linux-build
           path: linux/OpenSupaplex-linux.zip
@@ -33,7 +33,7 @@ jobs:
           ./macos/ci-build.sh
         shell: bash
       - name: Upload artifact
-        uses: actions/upload-artifact@v1
+        uses: actions/upload-artifact@v4
         with:
           name: macos-build
           path: macos/OpenSupaplex-macOS.zip
@@ -48,7 +48,7 @@ jobs:
           ./vita/ci-build-vita.sh
         shell: bash
       - name: Upload artifact
-        uses: actions/upload-artifact@v1
+        uses: actions/upload-artifact@v4
         with:
           name: vita-build
           path: vita/build/OpenSupaplex.vpk
@@ -63,7 +63,7 @@ jobs:
           ./switch/ci-build-switch.sh
         shell: bash
       - name: Upload artifact
-        uses: actions/upload-artifact@v1
+        uses: actions/upload-artifact@v4
         with:
           name: switch-build
           path: switch/OpenSupaplex-switch.zip
@@ -79,7 +79,7 @@ jobs:
           ./psp/ci-build.sh
         shell: bash
       - name: Upload artifact
-        uses: actions/upload-artifact@v1
+        uses: actions/upload-artifact@v4
         with:
           name: psp-build
           path: psp/OpenSupaplex-psp.zip
@@ -94,7 +94,7 @@ jobs:
           ./ps3/ci-build.sh
         shell: bash
       - name: Upload artifact
-        uses: actions/upload-artifact@v1
+        uses: actions/upload-artifact@v4
         with:
           name: ps3-build
           path: ps3/OpenSupaplex.pkg
@@ -109,7 +109,7 @@ jobs:
           ./wii/ci-build.sh
         shell: bash
       - name: Upload artifact
-        uses: actions/upload-artifact@v1
+        uses: actions/upload-artifact@v4
         with:
           name: wii-build
           path: wii/OpenSupaplex-wii.zip
@@ -124,7 +124,7 @@ jobs:
           ./wiiu/ci-build.sh
         shell: bash
       - name: Upload artifact
-        uses: actions/upload-artifact@v1
+        uses: actions/upload-artifact@v4
         with:
           name: wiiu-build
           path: wiiu/OpenSupaplex-wiiu.zip
@@ -139,7 +139,7 @@ jobs:
           ./nds/ci-build-nds.sh
         shell: bash
       - name: Upload artifact
-        uses: actions/upload-artifact@v1
+        uses: actions/upload-artifact@v4
         with:
           name: nds-build
           path: nds/OpenSupaplex.nds
@@ -154,7 +154,7 @@ jobs:
           ./3ds/ci-build-3ds.sh
         shell: bash
       - name: Upload artifact
-        uses: actions/upload-artifact@v1
+        uses: actions/upload-artifact@v4
         with:
           name: 3ds-build
           path: 3ds/OpenSupaplex-3ds.zip
@@ -169,7 +169,7 @@ jobs:
           ./riscos/ci-build.sh
         shell: bash
       - name: Upload artifact
-        uses: actions/upload-artifact@v1
+        uses: actions/upload-artifact@v4
         with:
           name: riscos-build
           path: riscos/OpenSupaplex-riscos.zip
@@ -188,7 +188,7 @@ jobs:
           cd windows
           msys2 -c './ci-build.sh x86_64'
       - name: Upload artifact
-        uses: actions/upload-artifact@v1
+        uses: actions/upload-artifact@v4
         with:
           name: windows-x86_64-build
           path: windows/OpenSupaplex-windows-x86_64.zip

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,7 @@ jobs:
           path: macos/OpenSupaplex-macOS.zip
   build-vita:
     name: PS Vita
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     container: sergiou87/vita-docker-open-supaplex:7.2
     steps:
       - uses: actions/checkout@v1
@@ -54,7 +54,7 @@ jobs:
           path: vita/build/OpenSupaplex.vpk
   build-switch:
     name: Nintendo Switch
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     container: sergiou87/switch-docker-open-supaplex:7.1
     steps:
       - uses: actions/checkout@v1
@@ -69,7 +69,7 @@ jobs:
           path: switch/OpenSupaplex-switch.zip
   build-psp:
     name: PSP
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     container: sergiou87/pspdev-docker-open-supaplex:7.1
     steps:
       - uses: actions/checkout@v1
@@ -85,7 +85,7 @@ jobs:
           path: psp/OpenSupaplex-psp.zip
   build-ps3:
     name: PS3
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     container: sergiou87/ps3dev-docker-open-supaplex:7.2
     steps:
       - uses: actions/checkout@v1
@@ -100,7 +100,7 @@ jobs:
           path: ps3/OpenSupaplex.pkg
   build-wii:
     name: Wii
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     container: sergiou87/wii-docker-open-supaplex:7.2
     steps:
       - uses: actions/checkout@v1
@@ -115,7 +115,7 @@ jobs:
           path: wii/OpenSupaplex-wii.zip
   build-wiiu:
     name: Wii U
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     container: sergiou87/wiiu-docker-open-supaplex:7.2
     steps:
       - uses: actions/checkout@v1
@@ -130,7 +130,7 @@ jobs:
           path: wiiu/OpenSupaplex-wiiu.zip
   build-nds:
     name: Nintendo DS
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     container: sergiou87/nds-docker-open-supaplex:7.2
     steps:
       - uses: actions/checkout@v1
@@ -145,7 +145,7 @@ jobs:
           path: nds/OpenSupaplex.nds
   build-3ds:
     name: Nintendo 3DS
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     container: sergiou87/3ds-docker-open-supaplex:7.1
     steps:
       - uses: actions/checkout@v1
@@ -160,7 +160,7 @@ jobs:
           path: 3ds/OpenSupaplex-3ds.zip
   build-riscos:
     name: RISC OS
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     container: sergiou87/riscos-docker-open-supaplex:7.2
     steps:
       - uses: actions/checkout@v1

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -32,7 +32,7 @@ jobs:
             || echo "::set-output name=run_tests_exit_code::1")
         shell: bash
       - name: Upload test results
-        uses: actions/upload-artifact@v1
+        uses: actions/upload-artifact@v4
         with:
           name: test-results
           path: tests/test-results.log

--- a/macos/OpenSupaplex/OpenSupaplex.xcodeproj/project.pbxproj
+++ b/macos/OpenSupaplex/OpenSupaplex.xcodeproj/project.pbxproj
@@ -996,6 +996,10 @@
 					"DEBUG=1",
 					"$(inherited)",
 				);
+				HEADER_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)/Frameworks/SDL2.framework/Headers",
+				);
 				INFOPLIST_FILE = "macOS-Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
@@ -1023,6 +1027,10 @@
 					"$(PROJECT_DIR)/Frameworks",
 				);
 				GCC_PREPROCESSOR_DEFINITIONS = HAVE_SDL2;
+				HEADER_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)/Frameworks/SDL2.framework/Headers",
+				);
 				INFOPLIST_FILE = "macOS-Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",

--- a/macos/OpenSupaplex/OpenSupaplex.xcodeproj/project.pbxproj
+++ b/macos/OpenSupaplex/OpenSupaplex.xcodeproj/project.pbxproj
@@ -264,8 +264,8 @@
 		400145AA2462CE9F00620211 /* utils.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = utils.h; path = ../../../src/utils.h; sourceTree = "<group>"; };
 		400145AB2462CE9F00620211 /* utils.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = utils.c; path = ../../../src/utils.c; sourceTree = "<group>"; };
 		4037C2152487DCFA001B4029 /* virtualKeyboard.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = virtualKeyboard.c; sourceTree = "<group>"; };
-		403839C5247E5D7900C1B08B /* audio.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = audio.c; path = audio.c; sourceTree = "<group>"; };
-		403839C6247E5D7900C1B08B /* system.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = system.c; path = system.c; sourceTree = "<group>"; };
+		403839C5247E5D7900C1B08B /* audio.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = audio.c; sourceTree = "<group>"; };
+		403839C6247E5D7900C1B08B /* system.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = system.c; sourceTree = "<group>"; };
 		403839CB247E5DAE00C1B08B /* logging.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = logging.c; path = ../../../src/logging.c; sourceTree = "<group>"; };
 		404824402485BA1200D13735 /* audio */ = {isa = PBXFileReference; lastKnownFileType = folder; name = audio; path = ../../resources/audio; sourceTree = "<group>"; };
 		404879BF246B51E600B776FA /* input.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = input.h; path = ../../../src/input.h; sourceTree = "<group>"; };
@@ -384,10 +384,10 @@
 		409F7DD9247B299100BB3B19 /* DEMO1.BIN */ = {isa = PBXFileReference; lastKnownFileType = archive.macbinary; name = DEMO1.BIN; path = ../../resources/DEMO1.BIN; sourceTree = "<group>"; };
 		409F7DDA247B299100BB3B19 /* LEVELS.D05 */ = {isa = PBXFileReference; lastKnownFileType = file; name = LEVELS.D05; path = ../../resources/LEVELS.D05; sourceTree = "<group>"; };
 		409F7F07247B35AE00BB3B19 /* keyboard.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = keyboard.h; path = ../../../src/keyboard.h; sourceTree = "<group>"; };
-		409F7F24247C74E300BB3B19 /* touchscreen.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = touchscreen.c; path = touchscreen.c; sourceTree = "<group>"; };
-		409F7F25247C74E300BB3B19 /* controller.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = controller.c; path = controller.c; sourceTree = "<group>"; };
-		409F7F26247C74E300BB3B19 /* video.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = video.c; path = video.c; sourceTree = "<group>"; };
-		409F7F27247C74E300BB3B19 /* keyboard.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = keyboard.c; path = keyboard.c; sourceTree = "<group>"; };
+		409F7F24247C74E300BB3B19 /* touchscreen.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = touchscreen.c; sourceTree = "<group>"; };
+		409F7F25247C74E300BB3B19 /* controller.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = controller.c; sourceTree = "<group>"; };
+		409F7F26247C74E300BB3B19 /* video.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = video.c; sourceTree = "<group>"; };
+		409F7F27247C74E300BB3B19 /* keyboard.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = keyboard.c; sourceTree = "<group>"; };
 		40C8290C24673197003A103E /* audio.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = audio.h; path = ../../../src/audio.h; sourceTree = "<group>"; };
 		40DA3CF62468717400D4A308 /* menu.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = menu.h; path = ../../../src/menu.h; sourceTree = "<group>"; };
 		40DA3CF72468717400D4A308 /* menu.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; name = menu.c; path = ../../../src/menu.c; sourceTree = "<group>"; };

--- a/ps3/Makefile
+++ b/ps3/Makefile
@@ -34,7 +34,7 @@ INCLUDES		:=	include
 # options for code generation
 #---------------------------------------------------------------------------------
 
-CFLAGS		=	-O2 -Wall -mcpu=cell $(MACHDEP) $(INCLUDE) $(LIBPSL1GHT_INC) -I$(PORTLIBS)/include -DHAVE_SDL2 -D__PSL1GHT__ -DPS3APPID=\"$(APPID)\"
+CFLAGS		=	-O2 -Wall -mcpu=cell $(MACHDEP) $(INCLUDE) $(LIBPSL1GHT_INC) -I$(PORTLIBS)/include -I$(PORTLIBS)/include/SDL2 -DHAVE_SDL2 -D__PSL1GHT__ -DPS3APPID=\"$(APPID)\"
 
 #---------------------------------------------------------------------------------
 # any extra libraries we wish to link with the project

--- a/src/logging.c
+++ b/src/logging.c
@@ -18,7 +18,7 @@
 #include "logging.h"
 
 #if HAVE_SDL2
-#include <SDL2/SDL.h>
+#include <SDL.h>
 #endif
 
 #if (defined(__vita__) || defined(__PSL1GHT__)) && DEBUG

--- a/src/nx/nxVirtualKeyboard.c
+++ b/src/nx/nxVirtualKeyboard.c
@@ -17,7 +17,7 @@
 
 #include "../virtualKeyboard.h"
 
-#include <SDL2/SDL.h>
+#include <SDL.h>
 #include <switch.h>
 
 #include "../logging.h"

--- a/src/ps3/virtualKeyboard.c
+++ b/src/ps3/virtualKeyboard.c
@@ -17,7 +17,7 @@
 
 #include "../virtualKeyboard.h"
 
-#include <SDL2/SDL.h>
+#include <SDL.h>
 
 #include <sys/memory.h>
 #include <sysutil/osk.h>

--- a/src/psp2/psp2VirtualKeyboard.c
+++ b/src/psp2/psp2VirtualKeyboard.c
@@ -17,7 +17,7 @@
 
 #include "../virtualKeyboard.h"
 
-#include <SDL2/SDL.h>
+#include <SDL.h>
 
 #include <psp2/apputil.h>
 #include <psp2/display.h>

--- a/src/sdl2/controller.c
+++ b/src/sdl2/controller.c
@@ -17,7 +17,7 @@
 
 #include "../controller.h"
 
-#include <SDL2/SDL.h>
+#include <SDL.h>
 #include <stdlib.h>
 
 static int sCurrentGameControllerIndex = -1;

--- a/src/sdl2/keyboard.c
+++ b/src/sdl2/keyboard.c
@@ -17,7 +17,7 @@
 
 #include "../keyboard.h"
 
-#include <SDL2/SDL.h>
+#include <SDL.h>
 
 #include "../system.h"
 

--- a/src/sdl2/touchscreen.c
+++ b/src/sdl2/touchscreen.c
@@ -17,7 +17,7 @@
 
 #include "../touchscreen.h"
 
-#include <SDL2/SDL.h>
+#include <SDL.h>
 
 uint8_t readTouchScreen(float *x, float *y)
 {

--- a/src/sdl2/video.c
+++ b/src/sdl2/video.c
@@ -18,7 +18,7 @@
 #include "../video.h"
 
 #include <math.h>
-#include <SDL2/SDL.h>
+#include <SDL.h>
 #include <stdlib.h>
 
 #include "../logging.h"

--- a/src/sdl_common/audio.c
+++ b/src/sdl_common/audio.c
@@ -20,7 +20,7 @@
 #include <math.h>
 
 #if HAVE_SDL2
-#include <SDL2/SDL.h>
+#include <SDL.h>
 #if TARGET_OS_MAC
 #include <SDL2_mixer/SDL_mixer.h>
 #else

--- a/src/sdl_common/system.c
+++ b/src/sdl_common/system.c
@@ -19,7 +19,7 @@
 
 #include <errno.h>
 #if HAVE_SDL2
-#include <SDL2/SDL.h>
+#include <SDL.h>
 #elif HAVE_SDL
 #include <SDL/SDL.h>
 #endif

--- a/src/utils.c
+++ b/src/utils.c
@@ -20,7 +20,7 @@
 #include <string.h>
 
 #if HAVE_SDL2
-#include <SDL2/SDL.h>
+#include <SDL.h>
 #elif HAVE_SDL
 #include <SDL/SDL.h>
 #endif

--- a/vita/CMakeLists.txt
+++ b/vita/CMakeLists.txt
@@ -18,8 +18,10 @@ set(VITA_VERSION  "07.20")
 
 option(DEBUGNET "Enable debugnet for logging" ON)
 
-set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -I${VITASDK}/include/SDL2 -std=gnu11 -DHAVE_SDL2")
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -I${VITASDK}/include/SDL2 -std=c++11 -DHAVE_SDL2")
+# Not a fan of adding -I${VITASDK}/arm-vita-eabi/include/SDL2 manually, but
+# the lack of sdl2-config makes it necessary.
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -I${VITASDK}/arm-vita-eabi/include/SDL2 -std=gnu11 -DHAVE_SDL2")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -I${VITASDK}/arm-vita-eabi/include/SDL2 -std=c++11 -DHAVE_SDL2")
 
 include_directories(
   ../common

--- a/vita/CMakeLists.txt
+++ b/vita/CMakeLists.txt
@@ -18,8 +18,8 @@ set(VITA_VERSION  "07.20")
 
 option(DEBUGNET "Enable debugnet for logging" ON)
 
-set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -std=gnu11 -DHAVE_SDL2")
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -DHAVE_SDL2")
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -I${VITASDK}/include/SDL2 -std=gnu11 -DHAVE_SDL2")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -I${VITASDK}/include/SDL2 -std=c++11 -DHAVE_SDL2")
 
 include_directories(
   ../common


### PR DESCRIPTION
This PR fixes the tests and for that it switches the `#include <SDL2/SDL.h>` to the intended `#include <SDL.h>` according to https://nullprogram.com/blog/2023/01/08/

For that I have to fix the CFLAGS of certain projects… I also noticed `upload-artifact` doesn't work in the latest containers so that forced me to use `v4` of those, and for that I had to update Ubuntu runners to their latest…

🧹 