### PR TITLE
Fix bug with panel visibility and save states

### DIFF
--- a/src/supaplex.c
+++ b/src/supaplex.c
@@ -5127,6 +5127,7 @@ void loadGameSnapshot() // loc_49A89:              ; CODE XREF: handleGameUserIn
     drawTextWithChars8FontToGamePanel(304, 14, 6, "LD"); // Means snapshot was loaded successfully
     gAdditionalInfoInGamePanelFrameCounter = 0x46;       // 70 or '&'
 
+    gCurrentPanelHeight = (gShouldShowGamePanel ? kPanelBitmapHeight : 0);
     drawCurrentLevelViewport(gCurrentPanelHeight);
     // videoLoop();
 


### PR DESCRIPTION
When a state is saved when the panel was hidden, and that state is loaded with the panel visible, the panel remains visible, but the playfield is behind the panel. If you press Enter the panel remains visible and the playfield is adjusted.
Likewise, if the panel is hidden and a state is loaded with the panel visible, you need to press Enter to show it.

Fix that issue by setting the gCurrentPanelHeight variable when loading a save state.