### PR TITLE
Linux: Fix Wayland crash on events before setup done

### DIFF
--- a/src/sdl2/video.c
+++ b/src/sdl2/video.c
@@ -143,7 +143,12 @@ void initializeVideo(uint8_t fastMode)
 
 void render()
 {
-    if (!gScreenSurface) return;
+    // In some cases (like using Wayland on Linux) some SDL events could be triggered
+    // and end up triggering a render before initializeVideo is done.
+    if (gScreenSurface == NULL)
+    {
+        return;
+    }
 
     SDL_BlitSurface(gScreenSurface, NULL, gTextureSurface, NULL);
 

--- a/src/sdl2/video.c
+++ b/src/sdl2/video.c
@@ -143,6 +143,8 @@ void initializeVideo(uint8_t fastMode)
 
 void render()
 {
+    if (!gScreenSurface) return;
+
     SDL_BlitSurface(gScreenSurface, NULL, gTextureSurface, NULL);
 
     SDL_UpdateTexture(gTexture, NULL, gTextureSurface->pixels, gTextureSurface->pitch);


### PR DESCRIPTION
Game crashed because SDL_CreateRenderer would setup Wayland event listeners which could get called before initializeVideo finishes. Resize event on tiling WMs presumably always crashes the game because it calls render before gTexture and other variables are initialized.

Fixes #66.